### PR TITLE
fix: Fix raycast shortcuts (fixes #196)

### DIFF
--- a/detour/src/main/java/org/recast4j/detour/LegacyNavMeshQuery.java
+++ b/detour/src/main/java/org/recast4j/detour/LegacyNavMeshQuery.java
@@ -341,7 +341,8 @@ public class LegacyNavMeshQuery extends NavMeshQuery {
                     Result<RaycastHit> rayHit = raycast(parentRef, parentNode.pos, neighbourNode.pos, m_query.filter,
                             DT_RAYCAST_USE_COSTS, grandpaRef);
                     if (rayHit.succeeded()) {
-                        foundShortCut = rayHit.result.t >= 1.0f;
+                        foundShortCut = rayHit.result.t >= 1.0f
+                                && rayHit.result.path.get(rayHit.result.path.size() - 1) == neighbourRef;
                         if (foundShortCut) {
                             // shortcut found using raycast. Using shorter cost
                             // instead

--- a/detour/src/main/java/org/recast4j/detour/NavMeshQuery.java
+++ b/detour/src/main/java/org/recast4j/detour/NavMeshQuery.java
@@ -812,7 +812,8 @@ public class NavMeshQuery {
                     Result<RaycastHit> rayHit = raycast(parentRef, parentNode.pos, neighbourPos, filter,
                             DT_RAYCAST_USE_COSTS, grandpaRef);
                     if (rayHit.succeeded()) {
-                        foundShortCut = rayHit.result.t >= 1.0f;
+                        foundShortCut = rayHit.result.t >= 1.0f
+                                && rayHit.result.path.get(rayHit.result.path.size() - 1) == neighbourRef;
                         if (foundShortCut) {
                             shortcut = rayHit.result.path;
                             // shortcut found using raycast. Using shorter cost
@@ -1101,7 +1102,8 @@ public class NavMeshQuery {
                     Result<RaycastHit> rayHit = raycast(parentRef, parentNode.pos, neighbourPos, m_query.filter,
                             DT_RAYCAST_USE_COSTS, grandpaRef);
                     if (rayHit.succeeded()) {
-                        foundShortCut = rayHit.result.t >= 1.0f;
+                        foundShortCut = rayHit.result.t >= 1.0f
+                                && rayHit.result.path.get(rayHit.result.path.size() - 1) == neighbourRef;
                         if (foundShortCut) {
                             shortcut = rayHit.result.path;
                             // shortcut found using raycast. Using shorter cost

--- a/recast-demo/src/main/java/org/recast4j/demo/tool/TestNavmeshTool.java
+++ b/recast-demo/src/main/java/org/recast4j/demo/tool/TestNavmeshTool.java
@@ -408,7 +408,7 @@ public class TestNavmeshTool implements Tool {
                     Result<RaycastHit> hit = m_navQuery.raycast(m_startRef, m_spos, m_epos, m_filter, 0, 0);
                     if (hit.succeeded()) {
                         m_polys = hit.result.path;
-                        if (hit.result.t > 1) {
+                        if (hit.result.t >= 1) {
                             // No hit
                             m_hitPos = Arrays.copyOf(m_epos, m_epos.length);
                             m_hitResult = false;


### PR DESCRIPTION
Raycast is performed in 2d and it might report reaching the given position even if the Y coordinate is different than the target. Therefore, it is necessary to check what poly is actually hit by raycast before taking a shortcut.